### PR TITLE
Reworked dlang architecture files, and correct 'compute' prototype.

### DIFF
--- a/architecture/minimal-dplug.d
+++ b/architecture/minimal-dplug.d
@@ -34,25 +34,6 @@
 
 // faust -a minimal.d -lang dlang noise.dsp -o noise.d
 
-/******************************************************************************
- *******************************************************************************
- 
- VECTOR INTRINSICS
- 
- *******************************************************************************
- *******************************************************************************/
-
-<<includeIntrinsic>>
-
-/********************END ARCHITECTURE SECTION (part 1/2)****************/
-
-/**************************BEGIN USER SECTION **************************/
-
-<<includeclass>>
-
-/***************************END USER SECTION ***************************/
-
-/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
 import std.stdio;
 import std.conv;
 import dplug.core.vec;
@@ -91,7 +72,21 @@ nothrow:
 
     void addHorizontalBargraph(string label, FAUSTFLOAT* val, FAUSTFLOAT min, FAUSTFLOAT max) {}
     void addVerticalBargraph(string label, FAUSTFLOAT* val, FAUSTFLOAT min, FAUSTFLOAT max) {}
+}
 
+interface dsp {
+nothrow:
+@nogc:
+public:
+    void metadata(Meta* m);
+    int getNumInputs();
+    int getNumOutputs();
+    void buildUserInterface(UI* uiInterface);
+    int getSampleRate();
+    void instanceInit(int sample_rate);
+    void instanceResetUserInterface();
+    void compute(int count, FAUSTFLOAT*[] inputs, FAUSTFLOAT*[] outputs);
+    void initialize(int sample_rate);
 }
 
 /**
@@ -161,5 +156,26 @@ struct FaustParam
 	FAUSTFLOAT step;
     bool isButton = false;
 }
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ VECTOR INTRINSICS
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+<<includeIntrinsic>>
+
+/********************END ARCHITECTURE SECTION (part 1/2)****************/
+
+/**************************BEGIN USER SECTION **************************/
+
+<<includeclass>>
+
+/***************************END USER SECTION ***************************/
+
+/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+
 /********************END ARCHITECTURE SECTION (part 2/2)****************/
 

--- a/architecture/minimal.d
+++ b/architecture/minimal.d
@@ -39,25 +39,6 @@ import std.algorithm;
 import std.format;
 import core.stdc.stdlib;
 
-/******************************************************************************
- *******************************************************************************
- 
- VECTOR INTRINSICS
- 
- *******************************************************************************
- *******************************************************************************/
-
-<<includeIntrinsic>>
-
-/********************END ARCHITECTURE SECTION (part 1/2)****************/
-
-/**************************BEGIN USER SECTION **************************/
-
-<<includeclass>>
-
-/***************************END USER SECTION ***************************/
-
-/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
 alias FAUSTFLOAT = float;
 
 class Meta {
@@ -92,8 +73,43 @@ nothrow:
 
     void addHorizontalBargraph(string label, FAUSTFLOAT* val, FAUSTFLOAT min, FAUSTFLOAT max) {}
     void addVerticalBargraph(string label, FAUSTFLOAT* val, FAUSTFLOAT min, FAUSTFLOAT max) {}
-
 }
+
+interface dsp {
+nothrow:
+@nogc:
+public:
+    void metadata(Meta* m);
+    int getNumInputs();
+    int getNumOutputs();
+    void buildUserInterface(UI* uiInterface);
+    int getSampleRate();
+    void instanceInit(int sample_rate);
+    void instanceResetUserInterface();
+    void compute(int count, FAUSTFLOAT*[] inputs, FAUSTFLOAT*[] outputs);
+    void initialize(int sample_rate);
+}
+
+/******************************************************************************
+ *******************************************************************************
+ 
+ VECTOR INTRINSICS
+ 
+ *******************************************************************************
+ *******************************************************************************/
+
+<<includeIntrinsic>>
+
+/********************END ARCHITECTURE SECTION (part 1/2)****************/
+
+/**************************BEGIN USER SECTION **************************/
+
+<<includeclass>>
+
+/***************************END USER SECTION ***************************/
+
+/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+
 
 enum int BUFFER_SIZE = 64;
 enum int SAMPLE_RATE = 44_100;

--- a/compiler/generator/dlang/dlang_code_container.cpp
+++ b/compiler/generator/dlang/dlang_code_container.cpp
@@ -144,24 +144,6 @@ void DLangCodeContainer::printHeader()
     *fOut << "module " << dModuleName(fKlassName) << ";\n";
 }
 
-void DLangCodeContainer::generateDSPInterface(int tabs)
-{
-    tab(tabs, *fOut);
-    *fOut << "interface dsp {\n";
-    *fOut << "nothrow:\n";
-    *fOut << "@nogc:\n";
-    *fOut << "public:\n";
-    *fOut << "    int getNumInputs();\n";
-    *fOut << "    int getNumOutputs();\n";
-    *fOut << "    void buildUserInterface(UI* uiInterface);\n";
-    *fOut << "    int getSampleRate();\n";
-    *fOut << "    void instanceInit(int sample_rate);\n";
-    *fOut << "    void instanceResetUserInterface();\n";
-    *fOut << "    void compute(int frames, " << ifloat()  << "*[] inputs, " << ifloat() << "*[] outputs);\n";
-    *fOut << "    void initialize(int sample_rate);\n";
-    *fOut << "}\n";
-}
-
 void DLangCodeContainer::produceInternal()
 {
     int n = 0;
@@ -268,8 +250,6 @@ void DLangCodeContainer::produceClass()
 
     *fOut << "alias FAUSTCLASS = " << fKlassName << ";" << endl;
     tab(n, *fOut);
-
-    generateDSPInterface(n);
 
     // Global declarations
     tab(n, *fOut);
@@ -441,7 +421,7 @@ void DLangScalarCodeContainer::generateCompute(int n)
     // Generates declaration
     tab(n + 1, *fOut);
     tab(n + 1, *fOut);
-    *fOut << subst("void compute(int $0, $1*[] inputs, $1*[] outputs) {", fFullCount, ifloat());
+    *fOut << subst("void compute(int $0, $1*[] inputs, $1*[] outputs) {", fFullCount, xfloat());
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
 
@@ -474,7 +454,7 @@ void DLangVectorCodeContainer::generateCompute(int n)
 
     // Generates declaration
     tab(n + 1, *fOut);
-    *fOut << subst("void compute(int $0, $1*[] inputs, $1*[] outputs) {", fFullCount, ifloat());
+    *fOut << subst("void compute(int $0, $1*[] inputs, $1*[] outputs) {", fFullCount, xfloat());
     tab(n + 2, *fOut);
     fCodeProducer.Tab(n + 2);
 

--- a/compiler/generator/dlang/dlang_code_container.hh
+++ b/compiler/generator/dlang/dlang_code_container.hh
@@ -57,8 +57,7 @@ class DLangCodeContainer : public virtual CodeContainer {
     virtual void produceClass();
     virtual void generateCompute(int tab) = 0;
     virtual void produceInternal();
-    virtual void generateDSPInterface(int tabs);
-
+  
     void generateImports(int tab);
     string dModuleName(string fKlassName);
 

--- a/tests/impulse-tests/archs/architecture.d
+++ b/tests/impulse-tests/archs/architecture.d
@@ -14,6 +14,12 @@ import core.stdc.stdint : uintptr_t;
 
 alias FAUSTFLOAT = double;
 
+class Meta {
+nothrow:
+@nogc:
+    void declare(string name, string value) {}
+}
+
 class UI {
 nothrow:
 @nogc:
@@ -40,7 +46,21 @@ nothrow:
 
     void addHorizontalBargraph(string label, FAUSTFLOAT* val, FAUSTFLOAT min, FAUSTFLOAT max){ }
     void addVerticalBargraph(string label, FAUSTFLOAT* val, FAUSTFLOAT min, FAUSTFLOAT max){ }
+}
 
+interface dsp {
+nothrow:
+@nogc:
+public:
+    void metadata(Meta* m);
+    int getNumInputs();
+    int getNumOutputs();
+    void buildUserInterface(UI* uiInterface);
+    int getSampleRate();
+    void instanceInit(int sample_rate);
+    void instanceResetUserInterface();
+    void compute(int count, FAUSTFLOAT*[] inputs, FAUSTFLOAT*[] outputs);
+    void initialize(int sample_rate);
 }
 
 enum int kFrames = 64;
@@ -115,7 +135,6 @@ nothrow:
         // -- metadata are not used
 
         override void declare(FAUSTFLOAT*, string, string) {}
-
 }
 
 //----------------------------------------------------------------------------
@@ -170,12 +189,6 @@ nothrow:
             kv.value = 0.123456789;
         }
     }
-}
-
-class Meta {
-nothrow:
-@nogc:
-    void declare(string name, string value) {}
 }
 
 static void printHeader(ref string irFile, mydsp DSP, int nbsamples)


### PR DESCRIPTION
After your last commit, which is not yet what we need ((-;
- `dsp` class definition is moved in architecture files (like we do in C++)
- `compute` method prototype has to use `FAUSTFLOAT`